### PR TITLE
ensure CLI passes proper rpc host and port info when launching GUI

### DIFF
--- a/ControlPanel.js
+++ b/ControlPanel.js
@@ -98,7 +98,10 @@ class ControlPanel extends BladeIronClient {
 				console.log(configDir)
 				const subprocess = spawn(path.join(topdir, 'node_modules', '.bin', 'electron'), ['.'], {
 					cwd: topdir,
-					env: { DISPLAY: process.env.DISPLAY, XAUTHORITY: process.env.XAUTHORITY,  PATH: process.env.PATH, configDir },
+					env: { DISPLAY: process.env.DISPLAY, 
+					       XAUTHORITY: process.env.XAUTHORITY, 
+					       PATH: process.env.PATH, 
+					       rpcport: this.rpcport, rpchost: this.rpchost, configDir },
 					detached: true,
 					stdio: 'ignore'
 				});


### PR DESCRIPTION
just to pass the rpc info from instance setup by CLI so that electron main.js can see it too. Docker needs this to work. 